### PR TITLE
exclude node_modules in Slither config

### DIFF
--- a/Ethos-Core/slither.config.json
+++ b/Ethos-Core/slither.config.json
@@ -1,4 +1,4 @@
 {
   "detectors_to_exclude": "naming-convention",
-  "filter_paths": "TestContracts|Dependencies|Migrations.sol|MultiTroveGetter.sol"
+  "filter_paths": "node_modules|TestContracts|Dependencies|Migrations.sol|MultiTroveGetter.sol"
 }

--- a/Ethos-Vaults/slither.config.json
+++ b/Ethos-Vaults/slither.config.json
@@ -1,0 +1,4 @@
+{
+  "detectors_to_exclude": "naming-convention",
+  "filter_paths": "node_modules"
+}


### PR DESCRIPTION
The links to the output in the README will need to be updated as well. I guess npm packages are definitely out of scope of this contest but it is debatable as to whether Wardens can glean anything useful from Slither's findings related to them. Of course Wardens will still be able to override the configs when running Slither locally.